### PR TITLE
Bump Security String to 2024-01-05

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -103,7 +103,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-    PLATFORM_SECURITY_PATCH := 2023-12-05
+    PLATFORM_SECURITY_PATCH := 2024-01-05
 endif
 
 include $(BUILD_SYSTEM)/version_util.mk


### PR DESCRIPTION
Implemented:
============
CVE:            References:    Type:  Severity:  Updated AOSP versions:
CVE-2023-21245  A-222446076    EoP    High       11, 12, 12L, 13, 14
CVE-2023-40085  A-269271098    ID     High       12, 12L, 13
CVE-2024-0015   A-300090204    EoP    High       11, 12, 12L, 13
CVE-2024-0016   A-279169188    ID     High       11, 12, 12L, 13, 14
CVE-2024-0017   A-285142084    ID     High       11, 12, 12L, 13, 14
CVE-2024-0018   A-300476626    EoP    High       11, 12, 12L, 13, 14
CVE-2024-0019   A-294104969    ID     High       12, 12L, 13, 14
CVE-2024-0020   A-299614635    ID     High       11, 12, 12L, 13, 14
CVE-2024-0021   A-282934003    EoP    High       13, 14
CVE-2024-0023   A-283099444    EoP    High       11, 12, 12L, 13, 14

Previously Implemented:
=======================
None

Not Implemented:
=======================
None

Not Applicable (platform source):
=================================
None

Change-Id: Ia9c522e1162b1bf2afea289a707748c2461c93c0